### PR TITLE
Add parens around unary operands if necessary

### DIFF
--- a/astformatter/__init__.py
+++ b/astformatter/__init__.py
@@ -434,7 +434,7 @@ class ASTFormatter(ast.NodeVisitor):
         return "-"
 
     def visit_UnaryOp(self, node):
-        return "%s %s" % (self.visit(node.op), self.visit(node.operand))
+        return "%s %s" % (self.visit(node.op), self.__parens(node.operand, node.op))
 
     def visit_withitem(self, node):
         if getattr(node, 'optional_vars', None) is None:

--- a/tests/features/astformatter.feature
+++ b/tests/features/astformatter.feature
@@ -165,3 +165,5 @@ Feature: Generate proper Python code
         | x + y * z                                             | x + y * z                                                 |
         | (x + y) * z                                           | (x + y) * z                                               |
         | x + (y * z)                                           | x + y * z                                                 |
+        | not (x and y)                                         | not (x and y)                                             |
+        | not x and y                                           | not x and y                                               |

--- a/tests/features/astformatter.feature
+++ b/tests/features/astformatter.feature
@@ -167,3 +167,4 @@ Feature: Generate proper Python code
         | x + (y * z)                                           | x + y * z                                                 |
         | not (x and y)                                         | not (x and y)                                             |
         | not x and y                                           | not x and y                                               |
+        | not x.y                                               | not x.y                                                   |


### PR DESCRIPTION
Unary operations can have higher precedence than their operands, for example in `not (x and y)` where the parens should not be omitted. This change makes a call to the `UnaryOp` visitor to call the utility function `self.__parens` to add any necessary parens around the operand.

Extended test suite to cover an example of this.

Thanks to @rmarianski for tracking this down!